### PR TITLE
Create UCSanDiego.ts

### DIFF
--- a/src/commands/UCSanDiego.ts
+++ b/src/commands/UCSanDiego.ts
@@ -12,7 +12,7 @@ export default class UCSanDiegoCommand extends Command {
       name: 'ucsd',
       enabled: true,
       description: 'Corrects the spelling of our glorious university, UC San Diego.',
-      category: 'Uncategorized',
+      category: 'Meme',
       usage: client.settings.prefix.concat('ucsd'),
       requiredPermissions: ['SEND_MESSAGES'],
     });

--- a/src/commands/UCSanDiego.ts
+++ b/src/commands/UCSanDiego.ts
@@ -3,6 +3,14 @@ import { Message } from 'discord.js';
 import Command from '../Command';
 import { BotClient } from '../types';
 
+const copypasta: string[] = [
+  'Using UC San Diego in place of the UCSD acronym better identifies our campus both',
+  'locally and nationally. There’s confusion among San Diego higher education institutions',
+  'because of similar acronyms—UCSD, USD, and SDSU—which we eliminate by using UC San Diego.',
+  'Additionally, this naming convention is consistent with other campuses in the University of',
+  'California system, such as UC Irvine, UC Riverside, UC Santa Barbara, UC Davis, and so on.'
+];
+
 /**
  * Command to correct the spelling of UC San Diego
  */
@@ -19,6 +27,6 @@ export default class UCSanDiegoCommand extends Command {
   }
 
   public async run(message: Message): Promise<void> {
-      await super.respond(message.channel, 'Using UC San Diego in place of the UCSD acronym better identifies our campus both locally and nationally. There’s confusion among San Diego higher education institutions because of similar acronyms—UCSD, USD, and SDSU—which we eliminate by using UC San Diego. Additionally, this naming convention is consistent with other campuses in the University of California system, such as UC Irvine, UC Riverside, UC Santa Barbara, UC Davis, and so on.');
+      await super.respond(message.channel, copypasta.join(' '));
   }
 }

--- a/src/commands/UCSanDiego.ts
+++ b/src/commands/UCSanDiego.ts
@@ -1,0 +1,24 @@
+
+import { Message } from 'discord.js';
+import Command from '../Command';
+import { BotClient } from '../types';
+
+/**
+ * Command to correct the spelling of UC San Diego
+ */
+export default class UCSanDiegoCommand extends Command {
+  constructor(client: BotClient) {
+    super(client, {
+      name: 'ucsd',
+      enabled: true,
+      description: 'Corrects the spelling of our glorious university, UC San Diego.',
+      category: 'Uncategorized',
+      usage: client.settings.prefix.concat('ucsd'),
+      requiredPermissions: ['SEND_MESSAGES'],
+    });
+  }
+
+  public async run(message: Message): Promise<void> {
+      await super.respond(message.channel, 'Using UC San Diego in place of the UCSD acronym better identifies our campus both locally and nationally. There’s confusion among San Diego higher education institutions because of similar acronyms—UCSD, USD, and SDSU—which we eliminate by using UC San Diego. Additionally, this naming convention is consistent with other campuses in the University of California system, such as UC Irvine, UC Riverside, UC Santa Barbara, UC Davis, and so on.');
+  }
+}


### PR DESCRIPTION
## University of California San Diego (no comma)
As we move forward to strengthen the brand, we will no longer use a comma when referencing the University of California San Diego. Our goals are to avoid the multiple variations currently used for naming the campus—University of California [at or in, or with the comma] San Diego—and to foster consistency, so use this name in all print and online applications.

## “UC San Diego” not “UCSD”
Using UC San Diego in place of the UCSD acronym better identifies our campus both locally and nationally. There’s confusion among San Diego higher education institutions because of similar acronyms—UCSD, USD, and SDSU—which we eliminate by using UC San Diego. Additionally, this naming convention is consistent with other campuses in the University of California system, such as UC Irvine, UC Riverside, UC Santa Barbara, UC Davis, and so on.

## Citing the Campus
In all communications efforts, please follow this protocol whenever possible:

First reference, spell out the name: University of California San Diego.
Subsequent references and in headlines, use the abbreviated version of the name: UC San Diego (not UCSD).
You can also use other words such as “campus” or “institution” to refer to UC San Diego in various communications efforts.
Name Use Reference
For information about the use of the University of California and UC San Diego names, please see http://go.ucsd.edu/1U7dzpO.

## Name Use Policy and Protocol
For information about policy and protocol related to the use of the University of California and UC San Diego name, please see the Use of the University of California Name guidelines.