### PR TITLE
Add staff as valid board role

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -68,10 +68,11 @@ export default abstract class Command {
       if (!memberRoles) {
         return false;
       }
+      const validRole = (role: string) => role.toLowerCase().includes('staff') || role.toLowerCase().includes('board');
 
       const isBoard = Array.isArray(memberRoles)
-        ? memberRoles.includes('Board')
-        : memberRoles.cache.some((r) => r.name === 'Board');
+        ? memberRoles.some((role) => validRole(role))
+        : memberRoles.cache.some((r) => validRole(r.name));
 
       if (this.conf.boardRequired && !isBoard) {
         interaction.reply(


### PR DESCRIPTION
- Add Staff as a valid role to use Board restricted commands
- Use .includes() so other roles (Diamond Staff, Cyber Board, etc.) are valid as well