### PR TITLE
Matcha load testing

### DIFF
--- a/src/commands/Matcha.ts
+++ b/src/commands/Matcha.ts
@@ -99,9 +99,6 @@ export default class Matcha extends Command {
    * @returns The total number of users who were matched.
    */
   private static async createMatches(interaction: CommandInteraction, users: GuildMember[]): Promise<Number> {
-    for (let i = 0; i < 90; i += 1) {
-      users.push(users[0]);
-    }
     const numMembersMatched = users.length;
     // Now, we make the pairings for Donuts members.
     const shuffledMembersList = Matcha.shuffle(users);

--- a/src/commands/Matcha.ts
+++ b/src/commands/Matcha.ts
@@ -99,6 +99,9 @@ export default class Matcha extends Command {
    * @returns The total number of users who were matched.
    */
   private static async createMatches(interaction: CommandInteraction, users: GuildMember[]): Promise<Number> {
+    for (let i = 0; i < 90; i += 1) {
+      users.push(users[0]);
+    }
     const numMembersMatched = users.length;
     // Now, we make the pairings for Donuts members.
     const shuffledMembersList = Matcha.shuffle(users);
@@ -138,7 +141,7 @@ export default class Matcha extends Command {
       await thread.send(
         `# 👋 Hello ${groupAsString} – time to meet up ‼️\nI'm here to help you :face_holding_back_tears: :index_pointing_at_the_viewer: get to know your teammates 🤩 by pairing everyone up every week 📆. Why don't you all pick a time ⏰ to meet up and get 🍵 🍣 🧋?`
       );
-      Logger.info(`/matcha - Matched ${groupAsString}`);
+      Logger.info(`/matcha - Matched ${memberTagsAsString}`);
       // Wait 200 ms before executing the next set of memberPairings.
       await setTimeout(() => {}, 200);
     }
@@ -186,12 +189,10 @@ export default class Matcha extends Command {
         }
         // Otherwise, the 'Confirm' button was called.
         this.lastRun = DateTime.now();
-        await buttonInteraction.deferReply();
-        await buttonInteraction.editReply({ content: 'Matching members!' });
         // Remove the button so they can't press it again.
-        await super.edit(interaction, { components: [] });
+        await super.edit(interaction, { content: 'Matching members!', components: [] });
         const numMembersMatched = await Matcha.createMatches(interaction, usersToBeMatched);
-        await buttonInteraction.editReply({
+        await interaction.followUp({
           content: `**/matcha** was called by ${interaction.user}: **${numMembersMatched}** members were successfully matched!`,
         });
       })

--- a/src/commands/Matcha.ts
+++ b/src/commands/Matcha.ts
@@ -11,6 +11,7 @@ import {
 import { DateTime } from 'luxon';
 import Command from '../Command';
 import { BotClient } from '../types';
+import Logger from '../utils/Logger';
 
 /**
  * Matches together users with a special role in groups of 2 or 3 in a Guild private thread.
@@ -137,6 +138,7 @@ export default class Matcha extends Command {
       await thread.send(
         `# 👋 Hello ${groupAsString} – time to meet up ‼️\nI'm here to help you :face_holding_back_tears: :index_pointing_at_the_viewer: get to know your teammates 🤩 by pairing everyone up every week 📆. Why don't you all pick a time ⏰ to meet up and get 🍵 🍣 🧋?`
       );
+      Logger.info(`/matcha - Matched ${groupAsString}`);
       // Wait 200 ms before executing the next set of memberPairings.
       await setTimeout(() => {}, 200);
     }


### PR DESCRIPTION
- Testing /matcha with large groups of users
- Added logging after each private thread has been successfully created and setup
- Rewrote slash command interaction to make more sense and work within the 15s response time after deferring a response
  - (Saved /matcha summary as a .followUp instead of a .edit since it doesn't rely on happening within 15s of deferring the original command)
  - It appears the original bug we had was an authentication bug that was fixed after resetting the perms and rebuilding and restarting BreadBot