### PR TITLE
Checkin fixes

### DIFF
--- a/src/commands/Checkin.ts
+++ b/src/commands/Checkin.ts
@@ -145,6 +145,7 @@ export default class Checkin extends Command {
           content: 'Check your DM.',
           ephemeral: true,
         });
+        await interaction.followUp(`**/checkin** was used by ${interaction.user}`);
       } else {
         // This is public, so we only want to give events that are live RIGHT now (so no one can
         // pre-emptively get checkin codes if they're left to be seen).
@@ -238,6 +239,9 @@ export default class Checkin extends Command {
       return (-2 * rescaledSize) / 3 + 65;
     };
 
+    // Importing DM Sans as our font
+    registerFont('./src/assets/DMSans-Bold.ttf', { family: 'DM Sans' });
+
     // Creating slide with Canvas
     // Helpful resource: https://blog.logrocket.com/creating-saving-images-node-canvas/
     const slide = createCanvas(1920, 1080);
@@ -255,9 +259,6 @@ export default class Checkin extends Command {
     const qrImg = await loadImage(await eventQrCode);
     context.drawImage(qrImg, 375, -325, 600, 600);
     context.rotate(-1 * angleInRadians);
-
-    // Importing DM Sans as our font
-    registerFont('./src/assets/DMSans-Bold.ttf', { family: 'DM Sans' });
 
     // Everything starting here has a shadow
     context.shadowColor = '#00000040';

--- a/src/commands/Checkin.ts
+++ b/src/commands/Checkin.ts
@@ -145,7 +145,7 @@ export default class Checkin extends Command {
           content: 'Check your DM.',
           ephemeral: true,
         });
-        await interaction.followUp(`**/checkin** was used by ${interaction.user}`);
+        await interaction.followUp(`**/checkin** was used privately by ${interaction.user}!`);
       } else {
         // This is public, so we only want to give events that are live RIGHT now (so no one can
         // pre-emptively get checkin codes if they're left to be seen).
@@ -165,7 +165,7 @@ export default class Checkin extends Command {
       });
       await super.edit(
         interaction,
-        `An error occurred when attempting to query the leaderboard data from the portal API. *(Error UUID: ${errorUUID})*`
+        `An error occurred when attempting to query the event data from the portal API. *(Error UUID: ${errorUUID})*`
       );
     }
   }
@@ -183,7 +183,6 @@ export default class Checkin extends Command {
         Authorization: `Bearer ${this.client.apiToken}`,
       },
     }).json()) as any;
-
     return portalAPIResponse.events.map((event: any) => ({
       ...event,
       start: DateTime.fromISO(event.start),

--- a/src/commands/Matcha.ts
+++ b/src/commands/Matcha.ts
@@ -131,9 +131,7 @@ export default class Matcha extends Command {
         type: 'GUILD_PRIVATE_THREAD',
         reason: `Matcha matching for ${memberTagsAsString}`,
       });
-      group.forEach(member => {
-        thread.members.add(member);
-      });
+      await Promise.all(group.map(member => thread.members.add(member)));
       await thread.send(
         `# 👋 Hello ${groupAsString} – time to meet up ‼️\nI'm here to help you :face_holding_back_tears: :index_pointing_at_the_viewer: get to know your teammates 🤩 by pairing everyone up every week 📆. Why don't you all pick a time ⏰ to meet up and get 🍵 🍣 🧋?`
       );


### PR DESCRIPTION
- Add a visible followUp message after using the private `now: false` option so people can view who is using /checkin privately
- Add font generation before creating a QR slide canvas to remove the bug where the font wouldn't load for check-in QR slides
- Make all Discord API calls in /matcha awaited so unexpected errors will hopefully stop happening