### PR TITLE
Remove unnecessary thread member add calls, reduce size of header mes…

### DIFF
--- a/src/commands/Matcha.ts
+++ b/src/commands/Matcha.ts
@@ -132,9 +132,8 @@ export default class Matcha extends Command {
         type: 'GUILD_PRIVATE_THREAD',
         reason: `Matcha matching for ${memberTagsAsString}`,
       });
-      await Promise.all(group.map(member => thread.members.add(member)));
       await thread.send(
-        `# 👋 Hello ${groupAsString} – time to meet up ‼️\nI'm here to help you :face_holding_back_tears: :index_pointing_at_the_viewer: get to know your teammates 🤩 by pairing everyone up every week 📆. Why don't you all pick a time ⏰ to meet up and get 🍵 🍣 🧋?`
+        `## 👋 Hello ${groupAsString} – time to meet up ‼️\nI'm here to help you :face_holding_back_tears: :index_pointing_at_the_viewer: get to know your teammates 🤩 by pairing everyone up every week 📆. Why don't you all pick a time ⏰ to meet up and get 🍵 🍣 🧋?`
       );
       Logger.info(`/matcha - Matched ${memberTagsAsString}`);
       // Wait 200 ms before executing the next set of memberPairings.


### PR DESCRIPTION
- Because sending a message that notifies members automatically adds members to the thread, we don't need `await Promise.all(group.map(member => thread.members.add(member)));`
- Reduced size of intro message from Heading 1 to Heading 2 